### PR TITLE
[WIP] Improve artifact choice

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,0 +1,178 @@
+use failure::{err_msg, format_err, Error};
+
+use std::process::Command;
+use std::{iter, str};
+
+use super::DEFAULT_CARGO_ARGS;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmdKind {
+    Run,
+    Test,
+}
+
+impl CmdKind {
+    /// Turns a string into a CmdKind
+    fn from_str(s: &str) -> Option<Self> {
+        use self::CmdKind::*;
+        match s {
+            "run" => Some(Run),
+            "test" => Some(Test),
+            _ => None,
+        }
+    }
+    /// Returns the respective command kind as a command to pass to
+    /// artifact generation
+    fn as_artifact_cmd(&self) -> &'static str {
+        match *self {
+            CmdKind::Run => "build",
+            CmdKind::Test => "test",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Cmd<'a> {
+    kind: CmdKind,
+    args: Vec<&'a str>,
+}
+
+impl<'a> Cmd<'a> {
+    /// Create a command from the given strings
+    pub fn from_strs(strs: impl IntoIterator<Item = &'a str>) -> Result<Self, Error> {
+        let mut strs = strs.into_iter();
+
+        let kind = strs
+            .next()
+            .ok_or(err_msg("Empty cargo command"))
+            .and_then(|kind_str| {
+                CmdKind::from_str(kind_str).ok_or({
+                    format_err!("Unable to convert '{}' into a cargo subcommand", kind_str)
+                })
+            })?;
+
+        Ok(Cmd {
+            kind,
+            args: strs.collect(),
+        })
+    }
+    pub fn kind(&self) -> CmdKind {
+        self.kind
+    }
+    /// Get the arguments which would be passed to `cargo`
+    ///
+    /// Includes the type of command (e.g `test`, `run`) and the default
+    /// arguments (`DEFAULT_CARGO_ARGS`).
+    fn args(&self) -> impl Iterator<Item = &str> + Clone {
+        iter::once(self.kind.as_artifact_cmd())
+            .chain(DEFAULT_CARGO_ARGS.iter().map(|s| *s))
+            .chain(self.args.iter().map(|s| *s))
+    }
+    /// Turn the arguements into a space separated string
+    fn args_str(&self) -> String {
+        self.args().fold(String::new(), |mut acc, arg| {
+            if !acc.is_empty() {
+                acc.push(' ');
+            }
+            acc += arg;
+            acc
+        })
+    }
+
+    /// Run the cargo command and get the output back as a vector
+    pub fn run(&self) -> Result<Vec<BuildOpt>, Error> {
+        debug!("Executing `cargo {}`", self.args_str());
+
+        let build_out = Command::new("cargo")
+            .args(self.args())
+            .output()
+            .map_err(|_| format_err!("Unable to run cargo command: `cargo {}`", self.args_str()))?;
+
+        if !build_out.status.success() {
+            Err(format_err!(
+                "{}\n{}\n\nCargo subcommand failed. Try running the original cargo command (without cargo-with)",
+                str::from_utf8(&build_out.stderr).unwrap(),
+                str::from_utf8(&build_out.stdout).unwrap()
+            ))?;
+        }
+
+        let opts = str::from_utf8(&build_out.stdout)
+            .map_err(|_| {
+                format_err!(
+                    "Output of `cargo {}` contained invalid UTF-8 characters",
+                    self.args_str()
+                )
+            })?
+            .lines()
+            // FIXME: There are plenty of errors here! This should really be better handled!
+            .flat_map(serde_json::from_str::<BuildOpt>)
+            .collect();
+
+        Ok(opts)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct BuildOpt {
+    pub features: Vec<String>,
+    pub filenames: Vec<std::path::PathBuf>,
+    pub fresh: bool,
+    pub package_id: String,
+    pub profile: Profile,
+    pub reason: String,
+    pub target: Target,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Profile {
+    pub debug_assertions: bool,
+    pub debuginfo: Option<u32>,
+    pub opt_level: String,
+    pub overflow_checks: bool,
+    pub test: bool,
+}
+
+/// Most possible targetkinds taken from
+/// [`TargetKind`](https://docs.rs/cargo/0.31.0/cargo/core/manifest/enum.TargetKind.html).
+/// See the implementation of `Serialize` for `TargetKind` to see how the enum
+/// is serialized (does not serialize as one would expect based on type
+/// signature).
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TargetKind {
+    Example,
+    Test,
+    Bin,
+    Lib,
+    Rlib,
+    Dylib,
+    ProcMacro,
+    Bench,
+    CustomBuild,
+}
+
+impl std::fmt::Display for TargetKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let name = match *self {
+            TargetKind::Example => "example",
+            TargetKind::Test => "test",
+            TargetKind::Bin => "bin",
+            TargetKind::Lib => "lib",
+            TargetKind::Rlib => "rlib",
+            TargetKind::Dylib => "dylib",
+            TargetKind::ProcMacro => "proc-macro",
+            TargetKind::Bench => "bench",
+            TargetKind::CustomBuild => "custom-build",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Target {
+    pub crate_types: Vec<String>,
+    pub edition: String,
+    pub kind: Vec<TargetKind>,
+    pub name: String,
+    pub src_path: std::path::PathBuf,
+}

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -90,7 +90,7 @@ impl<'a> Cmd<'a> {
 
         if !build_out.status.success() {
             Err(format_err!(
-                "{}\n{}\n\nCargo subcommand failed. Try running the original cargo command (without cargo-with)",
+                "{}\n{}\nCargo subcommand failed. Try running the original cargo command (without cargo-with)",
                 str::from_utf8(&build_out.stderr).unwrap(),
                 str::from_utf8(&build_out.stdout).unwrap()
             ))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,77 @@
+#[macro_use]
+extern crate log;
+extern crate failure;
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
+
+use std::process::Command;
+
+use failure::{err_msg, format_err, Error};
+
+mod cargo;
+use cargo::BuildOpt;
+
+const DEFAULT_CARGO_ARGS: &[&str] = &["--message-format=json", "--quiet"];
+
+pub fn run<'a, 'b>(
+    cargo_cmd_iter: impl Iterator<Item = &'a str>,
+    mut cmd_iter: impl Iterator<Item = &'b str>,
+) -> Result<(), Error> {
+    let cargo_cmd = cargo::Cmd::from_strs(cargo_cmd_iter)?;
+    let buildopts = cargo_cmd.run()?;
+
+    // Select the wanted buildopt
+    let buildopt = select_buildopt(buildopts.iter(), cargo_cmd.kind())?;
+    let artifact_path = buildopt.filenames[0].to_str().ok_or(format_err!(""))?;
+
+    // Separate the command from the arguments
+    let cmd = cmd_iter.next().ok_or(err_msg("Empty with command"))?;
+    let mut args: Vec<_> = cmd_iter.collect();
+
+    // Try to replace {bin} in the arguments with the artifact path
+    let replaced_bin = args
+        .iter_mut()
+        .find(|el| *el == &mut "{bin}")
+        .map(|el| *el = artifact_path)
+        .is_some();
+
+    // If we did not find {bin} in the args, add the artifact path as the last argument
+    if !replaced_bin {
+        args.push(artifact_path);
+    }
+
+    debug!("Executing `{} {}`", cmd, args.join(" "));
+
+    Command::new(cmd)
+        .args(args)
+        .spawn()
+        .expect("Failed to spawn child process")
+        .wait()?;
+
+    Ok(())
+}
+
+/// Selects the buildopt which fits with the requirements
+///
+/// If there are multiple possible candidates, this will return an error
+fn select_buildopt<'a>(
+    opts: impl Iterator<Item = &'a BuildOpt>,
+    _cmd_kind: cargo::CmdKind,
+) -> Result<&'a BuildOpt, Error> {
+    opts.last().ok_or(err_msg("Did not find any buildopts"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_ops() {
+        let json = "
+{\"features\":[],\"filenames\":[\"/home/christian/repos/rust/cargo-dbg/target/debug/cargo_dbg-813f65328e31d537\"],\"fresh\":true,\"package_id\":\"cargo-dbg 0.1.0 (path+file:///home/christian/repos/rust/cargo-dbg)\",\"profile\":{\"debug_assertions\":true,\"debuginfo\":2,\"opt_level\":\"0\",\"overflow_checks\":true,\"test\":true},\"reason\":\"compiler-artifact\",\"target\":{\"crate_types\":[\"bin\"],\"edition\":\"2015\",\"kind\":[\"bin\"],\"name\":\"cargo-dbg\",\"src_path\":\"/home/christian/repos/rust/cargo-dbg/src/main.rs\"}
+}";
+        let _opts: BuildOpt = serde_json::from_str(json).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ const COMMAND_NAME: &str = "with";
 const COMMAND_DESCRIPTION: &str =
     "A third-party cargo extension to run the build artifacts through tools like `gdb`";
 
-fn main() -> Result<(), Error> {
+fn runner() -> Result<(), Error> {
     env_logger::init();
 
     let app = create_app();
@@ -25,9 +25,23 @@ fn main() -> Result<(), Error> {
     cargo_with::run(cargo_cmd_iter, cmd_iter)
 }
 
+// Make a separate runner to print errors using Display instead of Debug
+fn main() {
+    if let Err(e) = runner() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
 fn process_matches<'a>(
     matches: &'a clap::ArgMatches,
-) -> Result<(impl Iterator<Item = &'a str>, impl Iterator<Item = &'a str>), Error> {
+) -> Result<
+    (
+        impl Iterator<Item = &'a str> + Clone,
+        impl Iterator<Item = &'a str> + Clone,
+    ),
+    Error,
+> {
     // The original cargo command
     let matches = matches
         .subcommand_matches(COMMAND_NAME)


### PR DESCRIPTION
Improves the choice of artifact by searching through all the artifacts and ~finding the artifact which has the same package name in `package_id` as the name of the current running package~ then picking the one that is either `bin`, `example`, `test` or marked as a test build (`profile.test == true`). The user has to use `--bin`, `--example`, `--test` and `--lib` to disambiguate the binary to be examined.

This may seem to add a lot of code, but most of it is gracefull and informative error handling. ~It will also always fall back to taking the last artifact upon any error searching~.

~TODO: Currently the code searches using `CARGO_PKG_NAME` hence this env variable needs to be set. This has to be set manually using `CARGO_PKG_NAME=my-package`, which is inconvenient. I'm looking into a better way of getting the name.~