### PR TITLE
Update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cargo-with"
 version = "0.2.0"
+edition = "2018"
 authors = ["cbourjau <christian.bourjau@cern.ch>"]
 categories = [
     "development-tools",
@@ -26,6 +27,5 @@ clap = "2.32"
 env_logger = "0.6.0"
 failure = "0.1.3"
 log = "0.4.5"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/cbourjau/cargo-with"
 
 [dependencies]
 clap = "2.32"
-env_logger = "0.5.13"
+env_logger = "0.6.0"
 failure = "0.1.3"
 log = "0.4.5"
 serde = "1.0"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,5 +1,6 @@
 use failure::{err_msg, format_err, Error};
 use log::debug;
+use serde::Deserialize;
 
 use std::path::PathBuf;
 use std::process::Command;

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,4 +1,5 @@
 use failure::{err_msg, format_err, Error};
+use log::debug;
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -160,7 +161,7 @@ enum TargetKind {
 }
 
 impl std::fmt::Display for TargetKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match *self {
             TargetKind::Example => "example",
             TargetKind::Test => "test",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate clap;
 extern crate env_logger;
 extern crate failure;
-#[macro_use]
 extern crate log;
 extern crate serde;
 #[macro_use]
@@ -10,10 +9,12 @@ extern crate serde_json;
 
 use clap::{App, AppSettings, Arg, SubCommand};
 use failure::{err_msg, Error};
+use log::debug;
 
 mod cargo;
 mod runner;
-use runner::runner;
+
+use crate::runner::runner;
 
 const COMMAND_NAME: &str = "with";
 const COMMAND_DESCRIPTION: &str =
@@ -33,7 +34,7 @@ fn main() -> Result<(), Error> {
 }
 
 fn process_matches<'a>(
-    matches: &'a clap::ArgMatches,
+    matches: &'a clap::ArgMatches<'_>,
 ) -> Result<
     (
         impl Iterator<Item = &'a str> + Clone,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,3 @@
-extern crate clap;
-extern crate env_logger;
-extern crate failure;
-extern crate log;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
 use clap::{App, AppSettings, Arg, SubCommand};
 use failure::{err_msg, Error};
 use log::debug;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,9 +1,10 @@
+use failure::{err_msg, Error};
+use log::debug;
+
 use std::iter::once;
 use std::process::Command;
 
-use failure::{err_msg, Error};
-
-use cargo;
+use crate::cargo;
 
 /// `cargo_cmd_iter` is an iterator over the cargo subcommand with arguments
 /// `cmd_iter` is an iterator over the the command to run the binary with


### PR DESCRIPTION
Here is the update to newer standards + moving to 2018 edition. One thing that I think is really nice is that now we only have to depend on `serde` and enable a feature for using `derive`. Further its nice to avoid all those `extern crate` statements. 