### PR TITLE
Pass through the child’s exit code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ failure = "0.1.3"
 log = "0.4.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+void = "1.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{App, AppSettings, Arg, SubCommand};
 use failure::{err_msg, Error};
 use log::debug;
+use void::{Void, unreachable};
 
 mod cargo;
 mod runner;
@@ -13,7 +14,7 @@ const COMMAND_DESCRIPTION: &str =
 
 fn main() {
     match mainer() {
-        Ok(()) => {}
+        Ok(v) => unreachable(v),
         Err(e) => {
             eprintln!("Error: {}", e);
             std::process::exit(1);
@@ -22,7 +23,7 @@ fn main() {
 }
 
 // Make a separate runner to print errors using Display instead of Debug
-fn mainer() -> Result<(), Error> {
+fn mainer() -> Result<Void, Error> {
     env_logger::init();
 
     let app = create_app();


### PR DESCRIPTION
Previously, `cargo with` would exit successfully even if the child failed.

This uses `exec()` on Unix for proper signal handling.